### PR TITLE
Add shebang for direct execution

### DIFF
--- a/CueMaker.py
+++ b/CueMaker.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ##################################
 #                                #
 #       Created by tralph3       #


### PR DESCRIPTION
Adding the shebang on the first line allows UNIX-based platforms to execute the file directly.