### PR TITLE
fix spelling error in GNU GPL section

### DIFF
--- a/cuemaker.py
+++ b/cuemaker.py
@@ -5,7 +5,7 @@
 #
 #This program is free software: you can redistribute it and/or modify
 #it under the terms of the GNU General Public License as published by
-#the Free Softwareation, either version 3 of the License, or
+#the Free Software Foundation, either version 3 of the License, or
 #(at your option) any later version.
 #
 #This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
Softwareation was probably not an intended change, changed back to Software Foundation